### PR TITLE
Date::class methods properly named

### DIFF
--- a/src/Date.php
+++ b/src/Date.php
@@ -2,11 +2,30 @@
 
 namespace Bosromania\PackageCommonTools;
 
-final class Date {
+final class Date
+{
+    static function readableDateDMY (int $time, bool $hour = true): string
+    {
+        if (date('Ymd') == date('Ymd', $time)) {
+            $format = "\\t\o\d\a\y" . ($hour ? " H:i" : '');
+        }
+        else if (date('Ymd', strtotime("-1 day")) == date('Ymd', $time)) {
+            $format = "\y\\e\s\\t\\e\\r\d\a\y" . ($hour ? " H:i" : '');
+        }
+        else {
+            $format = "d/m/Y";
 
-    static function readableDate (\DateTime $datetime, bool $hour = true): string {
-        $time = $datetime->getTimestamp();
+            // append hour, if not older that 3 days
+            if ((time() - $time) < 3*86400) {
+                $format .= " H:i";
+            }
+        }
 
+        return date($format, $time);
+    }
+
+    static function readableDateDFY (int $time, bool $hour = true): string
+    {
         if (date('Ymd') == date('Ymd', $time)) {
             $format = "\\t\o\d\a\y" . ($hour ? " H:i" : '');
         }


### PR DESCRIPTION
It now has two suggestive methods: `readableDateDMY()` and `readableDateDFY()`